### PR TITLE
Fixes error preventing admin from changing events.

### DIFF
--- a/routes/admin.js
+++ b/routes/admin.js
@@ -247,20 +247,13 @@ router.post("/changepassword/:id", utils.ensureAdmin, function(req, res) {
 });
 
 
-router.post("/event", utils.ensureAdmin, function(req, res) {
-  var event = req.body.event;
-//TODO: PUT THIS BACK IN WHEN WE FIGURE OUT WHY IT GIVES AN ERROR
-//  req.checkBody("event", "Please select an event!").notEmpty();
- body('event').notEmpty();
-
-  // var errors = req.validationErrors();
-  var errors = validationResult(req);
-  console.log(errors);
-  if (errors) {
+router.post("/event", utils.ensureAdmin, body("event").notEmpty(), (req, res) => {
+  const errors = validationResult(req);
+  if (!errors.isEmpty()) {
     TBA.getEvents(events => {
       res.render("event", {
-        errors: errors,
-        events: events
+        events: events,
+        errors: errors.array()
       });
     });
   } else {
@@ -282,6 +275,7 @@ router.post("/event", utils.ensureAdmin, function(req, res) {
     });
   }
 });
+
 
 
 

--- a/routes/admin.js
+++ b/routes/admin.js
@@ -253,7 +253,8 @@ router.post("/event", utils.ensureAdmin, function(req, res) {
 //  req.checkBody("event", "Please select an event!").notEmpty();
  body('event').notEmpty();
 
-  var errors = req.validationErrors();
+  // var errors = req.validationErrors();
+  var errors = validationResult(req);
   if (errors) {
     TBA.getEvents(events => {
       res.render("event", {

--- a/routes/admin.js
+++ b/routes/admin.js
@@ -243,7 +243,7 @@ router.post("/changepassword/:id", utils.ensureAdmin, function(req, res) {
 router.post("/event", utils.ensureAdmin, function(req, res) {
   var event = req.body.event;
 //TODO: PUT THIS BACK IN WHEN WE FIGURE OUT WHY IT GIVES AN ERROR
- // req.checkBody("event", "Please select an event!").notEmpty();
+ req.checkBody("event", "Please select an event!").notEmpty();
 
   var errors = req.validationErrors();
   if (errors) {

--- a/routes/admin.js
+++ b/routes/admin.js
@@ -1,10 +1,7 @@
 const express = require("express");
 
 const router = express.Router();
-// var expressValidator = require("express-validator");
-// router.use(expressValidator());
 const { body, validationResult } = require("express-validator");
-
 
 const User = require("../models/user");
 const Observation = require("../models/observation");
@@ -246,7 +243,6 @@ router.post("/changepassword/:id", utils.ensureAdmin, function(req, res) {
   );
 });
 
-
 router.post("/event", utils.ensureAdmin, body("event").notEmpty(), (req, res) => {
   const errors = validationResult(req);
   if (!errors.isEmpty()) {
@@ -276,41 +272,5 @@ router.post("/event", utils.ensureAdmin, body("event").notEmpty(), (req, res) =>
     });
   }
 });
-
-
-
-
-// router.post("/event", utils.ensureAdmin, function(req, res) {
-//   var event = req.body.event;
-// //TODO: PUT THIS BACK IN WHEN WE FIGURE OUT WHY IT GIVES AN ERROR
-//  req.checkBody("event", "Please select an event!").notEmpty();
-
-//   var errors = req.validationErrors();
-//   if (errors) {
-//     TBA.getEvents(events => {
-//       res.render("event", {
-//         errors: errors,
-//         events: events
-//       });
-//     });
-//   } else {
-//     fs.readFile("./config/state.db", function(err, buf) {
-//       if (err) throw err;
-
-//       var json = JSON.parse(buf.toString());
-//       json["current_event"] = event;
-
-//       fs.writeFile("./config/state.db", JSON.stringify(json), function(
-//         error,
-//         data
-//       ) {
-//         if (error) throw error;
-
-//         req.flash("success_msg", "Successfully changed event.");
-//         res.redirect("/admin/event");
-//       });
-//     });
-//   }
-// });
 
 module.exports = router;

--- a/routes/admin.js
+++ b/routes/admin.js
@@ -246,38 +246,40 @@ router.post("/changepassword/:id", utils.ensureAdmin, function(req, res) {
   );
 });
 
-router.post("/event",
-  utils.ensureAdmin,
-  body("event").notEmpty().withMessage("Please select an event!"),
-  (req, res) => {
-    const errors = validationResult(req);
-    if (errors) {
-      TBA.getEvents(events => {
-        res.render("event", {
-          errors: errors,
-          events: events
-        });
+
+router.post("/event", utils.ensureAdmin, function(req, res) {
+  var event = req.body.event;
+//TODO: PUT THIS BACK IN WHEN WE FIGURE OUT WHY IT GIVES AN ERROR
+//  req.checkBody("event", "Please select an event!").notEmpty();
+ body('event').notEmpty();
+
+  var errors = req.validationErrors();
+  if (errors) {
+    TBA.getEvents(events => {
+      res.render("event", {
+        errors: errors,
+        events: events
       });
-    } else {
-      fs.readFile("./config/state.db", function(err, buf) {
-        if (err) throw err;
-  
-        var json = JSON.parse(buf.toString());
-        json["current_event"] = event;
-  
-        fs.writeFile("./config/state.db", JSON.stringify(json), function(
-          error,
-          data
-        ) {
-          if (error) throw error;
-  
-          req.flash("success_msg", "Successfully changed event.");
-          res.redirect("/admin/event");
-        });
+    });
+  } else {
+    fs.readFile("./config/state.db", function(err, buf) {
+      if (err) throw err;
+
+      var json = JSON.parse(buf.toString());
+      json["current_event"] = event;
+
+      fs.writeFile("./config/state.db", JSON.stringify(json), function(
+        error,
+        data
+      ) {
+        if (error) throw error;
+
+        req.flash("success_msg", "Successfully changed event.");
+        res.redirect("/admin/event");
       });
-    }
+    });
   }
-);
+});
 
 
 

--- a/routes/admin.js
+++ b/routes/admin.js
@@ -1,8 +1,8 @@
 const express = require("express");
 
 const router = express.Router();
-var expressValidator = require("express-validator");
-router.use(expressValidator());
+// var expressValidator = require("express-validator");
+// router.use(expressValidator());
 
 
 const User = require("../models/user");

--- a/routes/admin.js
+++ b/routes/admin.js
@@ -261,6 +261,7 @@ router.post("/event", utils.ensureAdmin, body("event").notEmpty(), (req, res) =>
       if (err) throw err;
 
       var json = JSON.parse(buf.toString());
+      var event = req.body.event;
       json["current_event"] = event;
 
       fs.writeFile("./config/state.db", JSON.stringify(json), function(

--- a/routes/admin.js
+++ b/routes/admin.js
@@ -3,6 +3,7 @@ const express = require("express");
 const router = express.Router();
 // var expressValidator = require("express-validator");
 // router.use(expressValidator());
+const { body, validationResult } = require("express-validator");
 
 
 const User = require("../models/user");
@@ -245,37 +246,72 @@ router.post("/changepassword/:id", utils.ensureAdmin, function(req, res) {
   );
 });
 
-router.post("/event", utils.ensureAdmin, function(req, res) {
-  var event = req.body.event;
-//TODO: PUT THIS BACK IN WHEN WE FIGURE OUT WHY IT GIVES AN ERROR
- req.checkBody("event", "Please select an event!").notEmpty();
-
-  var errors = req.validationErrors();
-  if (errors) {
-    TBA.getEvents(events => {
-      res.render("event", {
-        errors: errors,
-        events: events
+router.post("/event",
+  utils.ensureAdmin,
+  body("event").notEmpty().withMessage("Please select an event!"),
+  (req, res) => {
+    const errors = validationResult(req);
+    if (errors) {
+      TBA.getEvents(events => {
+        res.render("event", {
+          errors: errors,
+          events: events
+        });
       });
-    });
-  } else {
-    fs.readFile("./config/state.db", function(err, buf) {
-      if (err) throw err;
-
-      var json = JSON.parse(buf.toString());
-      json["current_event"] = event;
-
-      fs.writeFile("./config/state.db", JSON.stringify(json), function(
-        error,
-        data
-      ) {
-        if (error) throw error;
-
-        req.flash("success_msg", "Successfully changed event.");
-        res.redirect("/admin/event");
+    } else {
+      fs.readFile("./config/state.db", function(err, buf) {
+        if (err) throw err;
+  
+        var json = JSON.parse(buf.toString());
+        json["current_event"] = event;
+  
+        fs.writeFile("./config/state.db", JSON.stringify(json), function(
+          error,
+          data
+        ) {
+          if (error) throw error;
+  
+          req.flash("success_msg", "Successfully changed event.");
+          res.redirect("/admin/event");
+        });
       });
-    });
+    }
   }
-});
+);
+
+
+
+// router.post("/event", utils.ensureAdmin, function(req, res) {
+//   var event = req.body.event;
+// //TODO: PUT THIS BACK IN WHEN WE FIGURE OUT WHY IT GIVES AN ERROR
+//  req.checkBody("event", "Please select an event!").notEmpty();
+
+//   var errors = req.validationErrors();
+//   if (errors) {
+//     TBA.getEvents(events => {
+//       res.render("event", {
+//         errors: errors,
+//         events: events
+//       });
+//     });
+//   } else {
+//     fs.readFile("./config/state.db", function(err, buf) {
+//       if (err) throw err;
+
+//       var json = JSON.parse(buf.toString());
+//       json["current_event"] = event;
+
+//       fs.writeFile("./config/state.db", JSON.stringify(json), function(
+//         error,
+//         data
+//       ) {
+//         if (error) throw error;
+
+//         req.flash("success_msg", "Successfully changed event.");
+//         res.redirect("/admin/event");
+//       });
+//     });
+//   }
+// });
 
 module.exports = router;

--- a/routes/admin.js
+++ b/routes/admin.js
@@ -1,5 +1,10 @@
 const express = require("express");
+
 const router = express.Router();
+var expressValidator = require("express-validator");
+router.use(expressValidator());
+
+
 const User = require("../models/user");
 const Observation = require("../models/observation");
 const utils = require("../utils");

--- a/routes/admin.js
+++ b/routes/admin.js
@@ -255,6 +255,7 @@ router.post("/event", utils.ensureAdmin, function(req, res) {
 
   // var errors = req.validationErrors();
   var errors = validationResult(req);
+  console.log(errors);
   if (errors) {
     TBA.getEvents(events => {
       res.render("event", {


### PR DESCRIPTION
When trying to change the current event from an admin account, the website would redirect to a blank html page containing the "TypeError: req.checkBody is not a function" error in the `admin.js` file. To fix this, I updated the code causing the error with the modern express-validator syntax. Admins can now change events with no error.